### PR TITLE
Allow Julia nightly version to fail

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,17 +16,18 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    continue-on-error: ${{ matrix.experimental }}
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1.6' # LTS
-          - '1.10'
-          - '1'
-          - 'nightly'
+        version: ['1.6', '1.10', '1']
+        experimental: [false]
+        include:
+          - version: 'nightly'
+            experimental: true
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,6 +28,7 @@ jobs:
         include:
           - version: 'nightly'
             os: ubuntu-latest
+            arch: x64
             experimental: true
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,7 @@ jobs:
         experimental: [false]
         include:
           - version: 'nightly'
+            os: ubuntu-latest
             experimental: true
         os:
           - ubuntu-latest


### PR DESCRIPTION
References:

- https://discourse.julialang.org/t/ignoring-nightly-failure-for-ci-badge/98028/5
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
