### PR TITLE
Update compat: Julia 1.10+, add JET 0.9/0.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,8 @@ LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
-julia = "1.6"
+julia = "1.10"
+JET = "0.9, 0.11"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"


### PR DESCRIPTION
## Summary
- Bump minimum Julia version from 1.6 to 1.10
- Add JET compat entry for versions 0.9 and 0.11

## Test plan
- [ ] CI passes on supported Julia versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)