### PR TITLE
Update JET.jl test configuration

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,9 +9,9 @@ using PkgBump
     Aqua.test_all(PkgBump, deps_compat=false)
 end
 
-if VERSION >= v"1.9"
+if VERSION >= v"1.10"
     @testset "Code linting (JET.jl)" begin
-        JET.test_package(PkgBump; target_defined_modules=true)
+        JET.test_package(PkgBump; target_modules=(PkgBump,))
     end
 end
 


### PR DESCRIPTION
## Summary
- Change minimum Julia version for JET tests from 1.9 to 1.10
- Update `test_package` call to use `target_modules=(PkgBump,)` instead of deprecated `target_defined_modules`

## Test plan
- [ ] CI passes with JET.jl tests on Julia 1.10+

🤖 Generated with [Claude Code](https://claude.com/claude-code)